### PR TITLE
Ensure that analog reads return unsigned values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.0.16
+
+* Bugfix: Ensure that analog reads return unsigned values.
+
 ### 0.0.15
 
 * Add the ability to do analog reads.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,7 +315,7 @@ int gpio_digital_read(CommandRouter *cmd, int argc, const char **argv) {
   uint8_t pin = strtol(argv[1], nullptr, 0);
   uint8_t value = digitalRead(pin);
 
-  snprintf(cmd->buffer, cmd->buffer_size, "%d", value);
+  snprintf(cmd->buffer, cmd->buffer_size, "%u", value);
   return 0;
 }
 
@@ -339,7 +339,7 @@ int analog_read(CommandRouter *cmd, int argc, const char **argv) {
   uint8_t pin = strtol(argv[1], nullptr, 0);
   uint8_t value = analogRead(pin);
 
-  snprintf(cmd->buffer, cmd->buffer_size, "%d", value);
+  snprintf(cmd->buffer, cmd->buffer_size, "%u", value);
   return 0;
 }
 


### PR DESCRIPTION
@vetonsaliu8 sorry for not catching this before I pressed merge.

We need to make sure that we return unsigned values.

![image](https://user-images.githubusercontent.com/90008/125668631-ecae9f19-f8dc-488e-a8bf-88408beccc4b.png)

https://en.cppreference.com/w/c/io/fprintf

Some versions of C++ compilers will give you intelligent warnings. Not too sure why platformio isn't doing it.

Will release this version soon.