### PR TITLE
[DRAFT] add i2c support for teensy 4.0 and 4.1

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,5 +23,7 @@ build_flags =
 platform = teensy
 board = teensy40
 framework = arduino
+lib_deps =
+    https://github.com/Richard-Gemmell/teensy4_i2c.git
 build_flags =
     !python versioneer.py

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -1,7 +1,14 @@
 #include "i2c.hpp"
 #include <errno.h>
-#if TEENSY_TO_ANY_HAS_I2C
+#if TEENSY_TO_ANY_HAS_I2C_T3
 #include <i2c_t3.h>
+#endif
+#if TEENSY_TO_ANY_HAS_I2C_T4
+#include <i2c_driver_wire.h>
+#endif
+
+
+#if TEENSY_TO_ANY_HAS_I2C
 int I2CMaster::init(int baudrate, int timeout_ms, int address_size,
                     int address_msb_first) {
   if (address_size != 2 && address_size != 1)

--- a/src/i2c.cpp
+++ b/src/i2c.cpp
@@ -8,7 +8,7 @@
 #endif
 
 
-#if TEENSY_TO_ANY_HAS_I2C
+#if TEENSY_TO_ANY_HAS_I2C_T3
 int I2CMaster::init(int baudrate, int timeout_ms, int address_size,
                     int address_msb_first) {
   if (address_size != 2 && address_size != 1)
@@ -270,6 +270,276 @@ int I2CMaster::read_no_register_uint8(int slave_address, uint8_t &data) {
 handle_error:
   while (Wire.available() != 0) {
     Wire.readByte();
+  }
+  return err;
+}
+#endif
+
+
+#if TEENSY_TO_ANY_HAS_I2C_T4
+bool I2C_NOSTOP = false;
+bool I2C_STOP = true;
+int I2CMaster_T4::init(int baudrate, int timeout_ms, int address_size,
+                    int address_msb_first) {
+  if (address_size != 2 && address_size != 1)
+    return ENOSYS;
+  if (address_msb_first != 0)
+    return ENOSYS;
+  Wire.begin();
+  //Wire.setDefaultTimeout(timeout_ms);
+  this->address_msb_first = address_msb_first;
+  this->address_size = address_size;
+  this->is_initialized = true;
+  return 0;
+}
+
+int I2CMaster_T4::reset() {
+  if (!this->is_initialized)
+    return ENODEV;
+  //Wire.resetBus();
+  return 0;
+}
+
+void I2CMaster_T4::_write_register_address(int register_address) {
+  if (this->address_size == 2) {
+    Wire.write((register_address >> 8) & 0xFF);
+    Wire.write((register_address >> 0) & 0xFF);
+  } else if (this->address_size == 1) {
+    Wire.write((register_address >> 0) & 0xFF);
+  }
+}
+
+int I2CMaster_T4::write_uint16(int slave_address, int register_address,
+                            uint16_t data) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  // Ensure the address is in write mode
+  Wire.beginTransmission(slave_address); // slave addr
+
+  this->_write_register_address(register_address);
+  // Assume MSB first for data as well
+  Wire.write((data >> 8) & 0xFF);
+  Wire.write((data >> 0) & 0xFF);
+  // blocking write (when not specified I2C_STOP is implicit)
+  Wire.endTransmission(I2C_STOP);
+
+  return Wire.getReadError(); //not sure this is correct?
+}
+
+int I2CMaster_T4::write_uint8(int slave_address, int register_address,
+                           uint8_t data) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  // Ensure the address is in write mode
+  Wire.beginTransmission(slave_address); // slave addr
+  this->_write_register_address(register_address);
+  Wire.write((data >> 0) & 0xFF);
+  // blocking write (when not specified I2C_STOP is implicit)
+  Wire.endTransmission(I2C_STOP);
+
+  return Wire.getReadError();
+}
+
+int I2CMaster_T4::write_no_register_uint8(int slave_address, uint8_t data) {
+  if (!this->is_initialized)
+    return ENODEV;
+
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+
+  Wire.beginTransmission(slave_address); // slave addr
+  Wire.write(data);
+  // blocking write (when not specified I2C_STOP is implicit)
+  Wire.endTransmission(I2C_STOP);
+
+  return Wire.getReadError();
+}
+
+int I2CMaster_T4::write_payload(int slave_address, int register_address,
+                             uint8_t *data, int num_bytes) {
+  if (!this->is_initialized)
+    return ENODEV;
+
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+
+  Wire.beginTransmission(slave_address); // slave addr
+  this->_write_register_address(register_address);
+  Wire.write(data, num_bytes);
+  // blocking write (when not specified I2C_STOP is implicit)
+  Wire.endTransmission(I2C_STOP);
+
+  return Wire.getReadError();
+}
+
+int I2CMaster_T4::read_payload(int slave_address, int register_address,
+                            uint8_t *data, int num_bytes) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  // Ensure the address is in write mode
+  uint8_t err;
+
+  Wire.beginTransmission(slave_address); // slave addr
+  // Write the MSB of the address first
+  this->_write_register_address(register_address);
+  Wire.endTransmission(
+      I2C_NOSTOP); // blocking write (when not specified I2C_STOP is implicit)
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  Wire.requestFrom(slave_address, num_bytes);
+  Wire.end();
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  if (Wire.available() != num_bytes) {
+    err = 3;
+    goto handle_error;
+  }
+
+  for (int i = 0; i < num_bytes; i++) {
+    data[i] = Wire.read();
+  }
+
+  return 0;
+
+handle_error:
+  while (Wire.available() != 0) {
+    Wire.read();
+  }
+  return err;
+}
+
+int I2CMaster_T4::read_uint16(int slave_address, int register_address,
+                           uint16_t &data) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  // Ensure the address is in write mode
+  uint8_t err;
+
+  Wire.beginTransmission(slave_address); // slave addr
+  // Write the MSB of the address first
+  this->_write_register_address(register_address);
+  Wire.endTransmission(
+      I2C_NOSTOP); // blocking write (when not specified I2C_STOP is implicit)
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  Wire.requestFrom(slave_address, 2);
+  Wire.end();
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  if (Wire.available() != 2) {
+    err = 3;
+    goto handle_error;
+  }
+
+  // Assume MSB is transfered first
+  data = Wire.read() << 8;
+  data = data | Wire.read();
+
+  return 0;
+
+handle_error:
+  while (Wire.available() != 0) {
+    Wire.read();
+  }
+  return err;
+}
+
+int I2CMaster_T4::read_uint8(int slave_address, int register_address,
+                          uint8_t &data) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  // Ensure the address is in write mode
+  uint8_t err;
+
+  Wire.beginTransmission(slave_address); // slave addr
+  // Write the MSB of the address first
+  this->_write_register_address(register_address);
+  Wire.endTransmission(
+      I2C_NOSTOP); // blocking write (when not specified I2C_STOP is implicit)
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  Wire.requestFrom(slave_address, 1);
+  Wire.end();
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  if (Wire.available() != 1) {
+    err = 3;
+    goto handle_error;
+  }
+
+  data = Wire.read();
+
+  return 0;
+
+handle_error:
+  while (Wire.available() != 0) {
+    Wire.read();
+  }
+  return err;
+}
+
+int I2CMaster_T4::read_no_register_uint8(int slave_address, uint8_t &data) {
+  if (!this->is_initialized)
+    return ENODEV;
+  // Wire library uses 7 bit addresses
+  if (slave_8bit_address)
+    slave_address = slave_address >> 1;
+  uint8_t err;
+  data = 0;
+
+  Wire.requestFrom(slave_address, 1);
+  Wire.end();
+  err = Wire.getReadError();
+  if (err) {
+    goto handle_error;
+  }
+
+  if (Wire.available() != 1) {
+    err = 3;
+    goto handle_error;
+  }
+
+  data = Wire.read();
+  return 0;
+
+handle_error:
+  while (Wire.available() != 0) {
+    Wire.read();
   }
   return err;
 }

--- a/src/i2c.hpp
+++ b/src/i2c.hpp
@@ -22,10 +22,37 @@
 #warning I2C library not available for this build.
 #endif
 
-#if TEENSY_TO_ANY_HAS_I2C
+#if TEENSY_TO_ANY_HAS_I2C_T3
 #include <unistd.h>
 
 class I2CMaster {
+public:
+  int init(int baudrate, int timeout_ms, int address_size,
+           int address_msb_first);
+  int reset();
+  int write_uint16(int slave_address, int register_address, uint16_t data);
+  int read_uint16(int slave_address, int register_address, uint16_t &data);
+  int write_uint8(int slave_address, int register_address, uint8_t data);
+  int read_uint8(int slave_address, int register_address, uint8_t &data);
+  int read_no_register_uint8(int slave_address, uint8_t &data);
+  int write_no_register_uint8(int slave_address, uint8_t data);
+  int write_payload(int slave_address, int register_address, uint8_t *data,
+                    int num_bytes);
+  int read_payload(int slave_address, int register_address, uint8_t *data,
+                   int num_bytes);
+
+private:
+  void _write_register_address(int register_address);
+  int address_msb_first = 0;
+  int address_size = 0;
+  bool is_initialized = false;
+  bool slave_8bit_address = true;
+};
+#endif
+
+#if TEENSY_TO_ANY_HAS_I2C_T4
+#include <unistd.h>
+class I2CMaster_T4 {
 public:
   int init(int baudrate, int timeout_ms, int address_size,
            int address_msb_first);

--- a/src/i2c.hpp
+++ b/src/i2c.hpp
@@ -4,6 +4,18 @@
 // https://docs.platformio.org/en/latest/platforms/teensy.html
 #if defined(TEENSYDUINO) && (defined(__MK20DX256__) ||                         \
                              defined(__MK64FX512__) || defined(__MK66FX1M0__))
+#define TEENSY_TO_ANY_HAS_I2C_T3 1
+#else
+#define TEENSY_TO_ANY_HAS_I2C_T3 0
+#endif
+
+#if defined(TEENSYDUINO) && defined(__IMXRT1062__)
+#define TEENSY_TO_ANY_HAS_I2C_T4 1
+#else
+#define TEENSY_TO_ANY_HAS_I2C_T4 0
+#endif
+
+#if (TEENSY_TO_ANY_HAS_I2C_T3 || TEENSY_TO_ANY_HAS_I2C_T4)
 #define TEENSY_TO_ANY_HAS_I2C 1
 #else
 #define TEENSY_TO_ANY_HAS_I2C 0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,8 +28,11 @@ inline SPISettings my_spi_settings() {
   return SPISettings(spi_baudrate, spi_bit_order, spi_data_mode);
 }
 
-#if TEENSY_TO_ANY_HAS_I2C
+#if TEENSY_TO_ANY_HAS_I2C_T3
 I2CMaster i2c;
+#endif
+#if TEENSY_TO_ANY_HAS_I2C_T4
+I2CMaster_T4 i2c;
 #endif
 
 void setup() {


### PR DESCRIPTION
still a work in progress but I think following the info in 

https://github.com/Richard-Gemmell/teensy4_i2c - (teensy 4 i2c support README)

https://github.com/nox771/i2c_t3 -  (teensy 3 i2c support README)

https://forum.pjrc.com/threads/62104-Teensy-4-and-4-1-pre-processor-defines?p=247546&viewfull=1#post247546 - (how to distiguish if we are on a teensy 4.0 or 4.1 board)

Still need to test this on a board though...