### PR TITLE
Provide a way to have post-startup commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.0 (2025/03/09)
 
 * Provide basic support for FastLED.
+* Provide a way to run commands immediately after the Serial Port has been setup.
 
 ### 0.7.0 (2025/03/03)
 

--- a/src/commandconstants.hpp
+++ b/src/commandconstants.hpp
@@ -85,6 +85,8 @@ int fastled_get_brightness(CommandRouter *cmd, int argc, const char **argv);
 int sleep_seconds(CommandRouter *cmd, int argc, const char **argv);
 int startup_commands_available(CommandRouter *cmd, int argc, const char **argv);
 int read_startup_command(CommandRouter *cmd, int argc, const char **argv);
+int post_serial_startup_commands_available(CommandRouter *cmd, int argc, const char **argv);
+int read_post_serial_startup_command(CommandRouter *cmd, int argc, const char **argv);
 int demo_commands_available(CommandRouter *cmd, int argc, const char **argv);
 int read_demo_command(CommandRouter *cmd, int argc, const char **argv);
 int disable_demo_commands(CommandRouter *cmd, int argc, const char **argv);
@@ -237,6 +239,10 @@ const command_item_t command_list[] = {
      "startup_commands_available", startup_commands_available},
     {"read_startup_command", "Read a startup command",
      "read_startup_command index", read_startup_command},
+    {"post_serial_startup_commands_available", "Number of post serial startup commands available",
+     "post_serial_startup_commands_available", startup_commands_available},
+    {"read_post_serial_startup_command", "Read a post serial startup command",
+     "read_post_serial_startup_command index", read_startup_command},
     {"demo_commands_available", "Number of demo commands available",
      "demo_commands_available", demo_commands_available},
     {"read_demo_command", "Read a demo command",

--- a/src/examples/fastled_demo/fastled_demo.cpp
+++ b/src/examples/fastled_demo/fastled_demo.cpp
@@ -14,6 +14,15 @@ const char *teensy_to_any_startup_commands[] = {
     "fastled_set_rgb 2 255 140 0",
     "fastled_set_rgb 3 255 140 0",
     "fastled_set_rgb 4 255 140 0",
+    "fastled_show 10",
+    nullptr,
+};
+
+const char *teensy_to_any_post_serial_startup_commands[] = {
+    // set color to orange to indicate that we aren't ready yet
+    // It takes about 2-3 seconds for the serial module to boot up
+    // The teensy will be unresponsive during this time.
+    "fastled_set_rgb 0 255 255 255",
     "fastled_show 30",
     nullptr,
 };

--- a/src/startup_commands.cpp
+++ b/src/startup_commands.cpp
@@ -3,7 +3,11 @@
 // enabling customization of these startup_commands depending
 // on the application
 __attribute__((weak)) const char *teensy_to_any_startup_commands[] = {
-    nullptr,
+  nullptr,
+};
+
+__attribute__((weak)) const char *teensy_to_any_post_serial_startup_commands[] = {
+  nullptr,
 };
 
 __attribute__((weak)) const char *teensy_to_any_demo_commands[] = {

--- a/src/startup_commands.hpp
+++ b/src/startup_commands.hpp
@@ -2,4 +2,5 @@
 // These commands can be defined by the user
 // see the startup_commands.cpp file for an example
 extern const char *teensy_to_any_startup_commands[];
+extern const char *teensy_to_any_post_serial_startup_commands[];
 extern const char *teensy_to_any_demo_commands[];


### PR DESCRIPTION
Serial takes like 2 second to boot up.

So it is nice to be able to do something before the bootup, and something immediately afterward.